### PR TITLE
Prevent default behavior when validation failed

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,6 +72,7 @@ export const TagsInput = ({
     }
 
     if (text && (separators || defaultSeparators).includes(e.key)) {
+      e.preventDefault();
       if (beforeAddValidate && !beforeAddValidate(text, tags)) return;
 
       if (tags.includes(text)) {
@@ -80,7 +81,6 @@ export const TagsInput = ({
       }
       setTags([...tags, text]);
       e.target.value = "";
-      e.preventDefault();
     }
   };
 


### PR DESCRIPTION
When I press enter and if validations are failed, It submits the form. We should prevent the default behavior of the event even if validation failed.