### PR TITLE
fixes typo `seprators` should be `separators`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ export default Example;
 | `classNames`        | className for styling input and tags (i.e {tag:'tag-cls', input: 'input-cls'})  | `object[tag, input]`                               |                 |
 | `onKeyUp`           | input `onKeyUp` callback                                                        | `event`                                            |                 |
 | `onBlur`            | input `onBlur` callback                                                         | `event`                                            |                 |
-| `seprators`         | when to add tag (i.e. `Space`,`Enter`)                                          | `string[]`                                         | `["Enter"]`     |
+| `separators`         | when to add tag (i.e. `Space`,`Enter`)                                          | `string[]`                                         | `["Enter"]`     |
 | `removers`          | Remove last tag if textbox empty and `Backspace` is pressed                     | `string[]`                                         | `["Backspace"]` |
 | `onExisting`        | if tag is already added then callback                                           | `(tag: string) => void`                            |                 |
 | `onRemoved`         | on tag removed callback                                                         | `(tag: string) => void`                            |                 |

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ export interface TagsInputProps {
   value?: string[];
   onChange?: (tags: string[]) => void;
   onBlur?: any;
-  seprators?: string[];
+  separators?: string[];
   disableBackspaceRemove?: boolean;
   onExisting?: (tag: string) => void;
   onRemoved?: (tag: string) => void;
@@ -26,7 +26,7 @@ export interface TagsInputProps {
   };
 }
 
-const defaultSeprators = ["Enter"];
+const defaultSeparators = ["Enter"];
 
 export const TagsInput = ({
   name,
@@ -34,7 +34,7 @@ export const TagsInput = ({
   value,
   onChange,
   onBlur,
-  seprators,
+  separators,
   disableBackspaceRemove,
   onExisting,
   onRemoved,
@@ -71,7 +71,7 @@ export const TagsInput = ({
       setTags([...tags.slice(0, -1)]);
     }
 
-    if (text && (seprators || defaultSeprators).includes(e.key)) {
+    if (text && (separators || defaultSeparators).includes(e.key)) {
       if (beforeAddValidate && !beforeAddValidate(text, tags)) return;
 
       if (tags.includes(text)) {


### PR DESCRIPTION
I thought this word looked funny... I think it was meant to be `separators`.